### PR TITLE
remove the need to pass in browser as parameter to the methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 
 # development
 watir-screenshot-stitch-*.gem
+
+Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ opts = { :page_height_limit => 5000 }
 
 b = Watir::Browser.new :firefox
 b.goto "https://github.com/mozilla/geckodriver/issues/570"
-b.screenshot.save_stitch(path, b, opts)
+b.screenshot.save_stitch(path, opts)
 ```
 
 will stitch together and save a full-page screenshot, up to 5000 pixels tall,
@@ -57,7 +57,7 @@ require 'watir-screenshot-stitch'
 
 b = Watir::Browser.new :firefox
 b.goto "https://github.com/watir/watir/issues/702"
-b.screenshot.base64_canvas(b)
+b.screenshot.base64_canvas
 ```
 
 will return a base64 encoded image blob of the given site.
@@ -71,14 +71,6 @@ as is the case for macOS 'Retina', and relies on this
 logic to determine how to stitch together images.
 This means that moving the browser window while it is be driven by
 Watir can cause unpredictable results.
-
-### Passing the browser?
-
-This is obviously awkward and obtuse. Because watir-screenshot-stitch
-patches Watir, it does not change the way Watir calls the Screenshot class,
-which does not know about the Browser instance (it instead knows
-about the driver). And watir-screenshot-stitch needs the browser to execute
-JavaScript on the page.
 
 ### Options
 
@@ -98,7 +90,7 @@ TODO: This.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/watir-screenshot-stitch. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/samnissen/watir-screenshot-stitch. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 

--- a/lib/watir-screenshot-stitch.rb
+++ b/lib/watir-screenshot-stitch.rb
@@ -11,24 +11,37 @@ MAXIMUM_SCREENSHOT_GENERATION_WAIT_TIME = 120
 RANGE_MOD = 0.02
 
 module Watir
+  class Browser
+    def screenshot
+      Screenshot.new self
+    end
+  end
+
   class Screenshot
+
+    def initialize(browser)
+      if browser.is_a? Selenium::WebDriver::Driver
+        msg = "Watir::Screenshot must be initialized with an instance of Watir::Browser to use watir-screenshot-stitch.gem"
+        raise ArgumentError, msg
+      end
+      @browser = browser
+      @driver = browser.wd
+    end
 
     #
     # Represents stitched together screenshot and writes to file.
     #
     # @example
     #   opts = {:page_height_limit => 5000}
-    #   browser.screenshot.save_stitch("path/abc.png", browser, opts)
+    #   browser.screenshot.save_stitch("path/abc.png", opts)
     #
     # @param [String] path
-    # @param [Watir::Browser] browser
     # @param [Hash] opts
     #
 
-    def save_stitch(path, browser, opts = {})
+    def save_stitch(path, opts = {})
       @options = opts
       @path = path
-      @browser = browser
       calculate_dimensions
 
       return self.save(@path) if (one_shot? || bug_shot?)
@@ -45,16 +58,13 @@ module Watir
     # of a full page screenshot.
     #
     # @example
-    #   browser.screenshot.base64_canvas(browser)
+    #   browser.screenshot.base64_canvas
     #   #=> '7HWJ43tZDscPleeUuPW6HhN3x+z7vU/lufmH0qNTtTum94IBWMT46evImci1vnFGT'
-    #
-    # @param [Watir::Browser] browser
     #
     # @return [String]
     #
 
-    def base64_canvas(browser)
-      @browser = browser
+    def base64_canvas
       output = nil
 
       return self.base64 if one_shot? || bug_shot?

--- a/spec/watir-screenshot-stitch_spec.rb
+++ b/spec/watir-screenshot-stitch_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Watir::Screenshot do
 
       @browser = Watir::Browser.new browser_key
       @browser.goto "https://github.com/mozilla/geckodriver/issues/570"
-      @browser.screenshot.save_stitch(@path, @browser, opts)
+      @browser.screenshot.save_stitch(@path, opts)
 
       expect(File).to exist(@path)
       expect(File.open(@path, "rb") { |io| io.read }[0..3]).to eq png_header
@@ -24,8 +24,7 @@ RSpec.describe Watir::Screenshot do
       image = MiniMagick::Image.open(@path)
       height = opts[:page_height_limit]
 
-      s = Watir::Screenshot.new(@browser.driver)
-      s.instance_variable_set(:@browser, @browser)
+      s = Watir::Screenshot.new(@browser)
       height = height * 2 if s.send(:retina?)
 
       expect(image.height).to be <= height
@@ -34,7 +33,7 @@ RSpec.describe Watir::Screenshot do
     it "gets a base64 screenshot payload" do
       @browser = Watir::Browser.new browser_key
       @browser.goto "https://github.com/mozilla/geckodriver/issues/570"
-      out = @browser.screenshot.base64_canvas(@browser)
+      out = @browser.screenshot.base64_canvas
 
       expect(out).to be_a(String)
       expect{
@@ -48,17 +47,15 @@ RSpec.describe Watir::Screenshot do
       @browser = Watir::Browser.new browser_key
       @browser.goto "https://google.com"
 
-      s = Watir::Screenshot.new(@browser.driver)
-      s.instance_variable_set(:@browser, @browser)
+      s = Watir::Screenshot.new(@browser)
       mac_factor   = 2 if s.send(:retina?)
       mac_factor ||= 1
 
-      image = MiniMagick::Image.read(Base64.decode64(@browser.screenshot.base64_canvas(@browser)))
+      image = MiniMagick::Image.read(Base64.decode64(@browser.screenshot.base64_canvas))
       page_height = (@browser.execute_script "return Math.max( document.documentElement.scrollHeight, document.documentElement.getBoundingClientRect().height )").to_f.to_i
       expect(image.height).to eq(page_height*mac_factor)
 
-      s = Watir::Screenshot.new @browser.driver
-      s.instance_variable_set(:@browser, @browser)
+      s = Watir::Screenshot.new @browser
       expect(s.send(:one_shot?)).to be_truthy
     end
 
@@ -74,7 +71,7 @@ RSpec.describe Watir::Screenshot do
     # it "stops taking screenshots when given full screenshot" do
       # @browser = Watir::Browser.new browser_key
       # @browser.goto "https://sixcolors.com"
-      # image = MiniMagick::Image.read(Base64.decode64(@browser.screenshot.base64_canvas(@browser)))
+      # image = MiniMagick::Image.read(Base64.decode64(@browser.screenshot.base64_canvas))
       # page_height = (@browser.execute_script "return Math.max( document.documentElement.scrollHeight, document.documentElement.getBoundingClientRect().height )").to_f.to_i
       # expect(image.height).to eq(page_height)
       # expect(s.send(:bug_shot?)).to be_truthy
@@ -91,7 +88,7 @@ RSpec.describe Watir::Screenshot do
 
       @browser = Watir::Browser.new browser_key
       @browser.goto "https://github.com/mozilla/geckodriver/issues/570"
-      @browser.screenshot.save_stitch(@path, @browser, opts)
+      @browser.screenshot.save_stitch(@path, opts)
 
       expect(File).to exist(@path)
       expect(File.open(@path, "rb") { |io| io.read }[0..3]).to eq png_header
@@ -99,8 +96,7 @@ RSpec.describe Watir::Screenshot do
       image = MiniMagick::Image.open(@path)
       height = opts[:page_height_limit]
 
-      s = Watir::Screenshot.new(@browser.driver)
-      s.instance_variable_set(:@browser, @browser)
+      s = Watir::Screenshot.new(@browser)
       height = height * 2 if s.send(:retina?)
 
       expect(image.height).to be <= height
@@ -109,7 +105,7 @@ RSpec.describe Watir::Screenshot do
     it "gets a base64 screenshot payload" do
       @browser = Watir::Browser.new browser_key
       @browser.goto "https://github.com/mozilla/geckodriver/issues/570"
-      out = @browser.screenshot.base64_canvas(@browser)
+      out = @browser.screenshot.base64_canvas
 
       expect(out).to be_a(String)
       expect{
@@ -123,17 +119,15 @@ RSpec.describe Watir::Screenshot do
       @browser = Watir::Browser.new browser_key
       @browser.goto "https://google.com"
 
-      s = Watir::Screenshot.new(@browser.driver)
-      s.instance_variable_set(:@browser, @browser)
+      s = Watir::Screenshot.new(@browser)
       mac_factor   = 2 if s.send(:retina?)
       mac_factor ||= 1
 
-      image = MiniMagick::Image.read(Base64.decode64(@browser.screenshot.base64_canvas(@browser)))
+      image = MiniMagick::Image.read(Base64.decode64(@browser.screenshot.base64_canvas))
       page_height = (@browser.execute_script "return Math.max( document.documentElement.scrollHeight, document.documentElement.getBoundingClientRect().height )").to_f.to_i
       expect(image.height).to eq(page_height*mac_factor)
 
-      s = Watir::Screenshot.new @browser.driver
-      s.instance_variable_set(:@browser, @browser)
+      s = Watir::Screenshot.new @browser
       expect(s.send(:one_shot?)).to be_truthy
     end
   end


### PR DESCRIPTION
The goal is to get rid of the need to pass in a `Browser` instance.

The first question is if we need to maintain backward compatibility, or if we're ok just having everyone who wants to update have to change their code.

The second question is whether you want to override what is in Watir now, or to wait for https://github.com/watir/watir/issues/731 to get added and Watir 6.12 released.

This PR shows how you can update the code right now in a way that is not backward compatible. Assuming Watir 6.12 includes the code from that PR, you would only need to remove the `Browser#screenshot` and `Screenshot#initialize` methods and force the version in the gemfile.


