### PR TITLE
remove the need to pass in browser as parameter to the methods

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,22 @@
 PATH
   remote: .
   specs:
-    watir-screenshot-stitch (0.6.4)
+    watir-screenshot-stitch (0.6.5)
       binding_of_caller (~> 0.7)
       mini_magick (~> 4.0)
       os (~> 1.0)
-      watir (~> 6.4)
+      watir (~> 6.12)
 
 GEM
   remote: https://rubygems.org/
   specs:
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
-    childprocess (0.8.0)
+    childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
-    ffi (1.9.18)
+    ffi (1.9.25)
     mini_magick (4.8.0)
     os (1.0.0)
     rake (10.5.0)
@@ -34,10 +34,10 @@ GEM
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
     rubyzip (1.2.1)
-    selenium-webdriver (3.8.0)
+    selenium-webdriver (3.14.0)
       childprocess (~> 0.5)
-      rubyzip (~> 1.0)
-    watir (6.10.2)
+      rubyzip (~> 1.2)
+    watir (6.12.0)
       selenium-webdriver (~> 3.4, >= 3.4.1)
 
 PLATFORMS
@@ -50,4 +50,4 @@ DEPENDENCIES
   watir-screenshot-stitch!
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ opts = { :page_height_limit => 5000 }
 
 b = Watir::Browser.new :firefox
 b.goto "https://github.com/mozilla/geckodriver/issues/570"
-b.screenshot.save_stitch(path, b, opts)
+b.screenshot.save_stitch(path, opts)
 ```
 
 will stitch together and save a full-page screenshot, up to 5000 pixels tall,
@@ -57,7 +57,7 @@ require 'watir-screenshot-stitch'
 
 b = Watir::Browser.new :firefox
 b.goto "https://github.com/watir/watir/issues/702"
-b.screenshot.base64_canvas(b)
+b.screenshot.base64_canvas
 ```
 
 will return a base64 encoded image blob of the given site.
@@ -71,14 +71,6 @@ as is the case for macOS 'Retina', and relies on this
 logic to determine how to stitch together images.
 This means that moving the browser window while it is be driven by
 Watir can cause unpredictable results.
-
-### Passing the browser?
-
-This is obviously awkward and obtuse. Because watir-screenshot-stitch
-patches Watir, it does not change the way Watir calls the Screenshot class,
-which does not know about the Browser instance (it instead knows
-about the driver). And watir-screenshot-stitch needs the browser to execute
-JavaScript on the page.
 
 ### Options
 
@@ -98,7 +90,7 @@ TODO: This.
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/watir-screenshot-stitch. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/samnissen/watir-screenshot-stitch. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 

--- a/lib/watir-screenshot-stitch.rb
+++ b/lib/watir-screenshot-stitch.rb
@@ -73,7 +73,7 @@ module Watir
       end
 
       def bug_shot?
-        return false unless @browser.name == :firefox
+        return false unless @browser&.name == :firefox
         calculate_dimensions unless @page_height
 
         image = MiniMagick::Image.read(Base64.decode64(self.base64))

--- a/lib/watir-screenshot-stitch.rb
+++ b/lib/watir-screenshot-stitch.rb
@@ -18,17 +18,15 @@ module Watir
     #
     # @example
     #   opts = {:page_height_limit => 5000}
-    #   browser.screenshot.save_stitch("path/abc.png", browser, opts)
+    #   browser.screenshot.save_stitch("path/abc.png", opts)
     #
     # @param [String] path
-    # @param [Watir::Browser] browser
     # @param [Hash] opts
     #
 
-    def save_stitch(path, browser, opts = {})
+    def save_stitch(path, opts = {})
       @options = opts
       @path = path
-      @browser = browser
       calculate_dimensions
 
       return self.save(@path) if (one_shot? || bug_shot?)
@@ -45,16 +43,13 @@ module Watir
     # of a full page screenshot.
     #
     # @example
-    #   browser.screenshot.base64_canvas(browser)
+    #   browser.screenshot.base64_canvas
     #   #=> '7HWJ43tZDscPleeUuPW6HhN3x+z7vU/lufmH0qNTtTum94IBWMT46evImci1vnFGT'
-    #
-    # @param [Watir::Browser] browser
     #
     # @return [String]
     #
 
-    def base64_canvas(browser)
-      @browser = browser
+    def base64_canvas
       output = nil
 
       return self.base64 if one_shot? || bug_shot?
@@ -78,7 +73,7 @@ module Watir
       end
 
       def bug_shot?
-        return false unless @browser&.name == :firefox
+        return false unless @browser.name == :firefox
         calculate_dimensions unless @page_height
 
         image = MiniMagick::Image.read(Base64.decode64(self.base64))

--- a/spec/watir-screenshot-stitch_spec.rb
+++ b/spec/watir-screenshot-stitch_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Watir::Screenshot do
 
       @browser = Watir::Browser.new browser_key
       @browser.goto "https://github.com/mozilla/geckodriver/issues/570"
-      @browser.screenshot.save_stitch(@path, @browser, opts)
+      @browser.screenshot.save_stitch(@path, opts)
 
       expect(File).to exist(@path)
       expect(File.open(@path, "rb") { |io| io.read }[0..3]).to eq png_header
@@ -24,8 +24,7 @@ RSpec.describe Watir::Screenshot do
       image = MiniMagick::Image.open(@path)
       height = opts[:page_height_limit]
 
-      s = Watir::Screenshot.new(@browser.driver)
-      s.instance_variable_set(:@browser, @browser)
+      s = Watir::Screenshot.new(@browser)
       height = height * 2 if s.send(:retina?)
 
       expect(image.height).to be <= height
@@ -34,7 +33,7 @@ RSpec.describe Watir::Screenshot do
     it "gets a base64 screenshot payload" do
       @browser = Watir::Browser.new browser_key
       @browser.goto "https://github.com/mozilla/geckodriver/issues/570"
-      out = @browser.screenshot.base64_canvas(@browser)
+      out = @browser.screenshot.base64_canvas
 
       expect(out).to be_a(String)
       expect{
@@ -48,17 +47,15 @@ RSpec.describe Watir::Screenshot do
       @browser = Watir::Browser.new browser_key
       @browser.goto "https://google.com"
 
-      s = Watir::Screenshot.new(@browser.driver)
-      s.instance_variable_set(:@browser, @browser)
+      s = Watir::Screenshot.new(@browser)
       mac_factor   = 2 if s.send(:retina?)
       mac_factor ||= 1
 
-      image = MiniMagick::Image.read(Base64.decode64(@browser.screenshot.base64_canvas(@browser)))
+      image = MiniMagick::Image.read(Base64.decode64(@browser.screenshot.base64_canvas))
       page_height = (@browser.execute_script "return Math.max( document.documentElement.scrollHeight, document.documentElement.getBoundingClientRect().height )").to_f.to_i
       expect(image.height).to eq(page_height*mac_factor)
 
-      s = Watir::Screenshot.new @browser.driver
-      s.instance_variable_set(:@browser, @browser)
+      s = Watir::Screenshot.new @browser
       expect(s.send(:one_shot?)).to be_truthy
     end
 
@@ -74,7 +71,7 @@ RSpec.describe Watir::Screenshot do
     # it "stops taking screenshots when given full screenshot" do
       # @browser = Watir::Browser.new browser_key
       # @browser.goto "https://sixcolors.com"
-      # image = MiniMagick::Image.read(Base64.decode64(@browser.screenshot.base64_canvas(@browser)))
+      # image = MiniMagick::Image.read(Base64.decode64(@browser.screenshot.base64_canvas))
       # page_height = (@browser.execute_script "return Math.max( document.documentElement.scrollHeight, document.documentElement.getBoundingClientRect().height )").to_f.to_i
       # expect(image.height).to eq(page_height)
       # expect(s.send(:bug_shot?)).to be_truthy
@@ -91,7 +88,7 @@ RSpec.describe Watir::Screenshot do
 
       @browser = Watir::Browser.new browser_key
       @browser.goto "https://github.com/mozilla/geckodriver/issues/570"
-      @browser.screenshot.save_stitch(@path, @browser, opts)
+      @browser.screenshot.save_stitch(@path, opts)
 
       expect(File).to exist(@path)
       expect(File.open(@path, "rb") { |io| io.read }[0..3]).to eq png_header
@@ -99,8 +96,7 @@ RSpec.describe Watir::Screenshot do
       image = MiniMagick::Image.open(@path)
       height = opts[:page_height_limit]
 
-      s = Watir::Screenshot.new(@browser.driver)
-      s.instance_variable_set(:@browser, @browser)
+      s = Watir::Screenshot.new(@browser)
       height = height * 2 if s.send(:retina?)
 
       expect(image.height).to be <= height
@@ -109,7 +105,7 @@ RSpec.describe Watir::Screenshot do
     it "gets a base64 screenshot payload" do
       @browser = Watir::Browser.new browser_key
       @browser.goto "https://github.com/mozilla/geckodriver/issues/570"
-      out = @browser.screenshot.base64_canvas(@browser)
+      out = @browser.screenshot.base64_canvas
 
       expect(out).to be_a(String)
       expect{
@@ -123,17 +119,15 @@ RSpec.describe Watir::Screenshot do
       @browser = Watir::Browser.new browser_key
       @browser.goto "https://google.com"
 
-      s = Watir::Screenshot.new(@browser.driver)
-      s.instance_variable_set(:@browser, @browser)
+      s = Watir::Screenshot.new(@browser)
       mac_factor   = 2 if s.send(:retina?)
       mac_factor ||= 1
 
-      image = MiniMagick::Image.read(Base64.decode64(@browser.screenshot.base64_canvas(@browser)))
+      image = MiniMagick::Image.read(Base64.decode64(@browser.screenshot.base64_canvas))
       page_height = (@browser.execute_script "return Math.max( document.documentElement.scrollHeight, document.documentElement.getBoundingClientRect().height )").to_f.to_i
       expect(image.height).to eq(page_height*mac_factor)
 
-      s = Watir::Screenshot.new @browser.driver
-      s.instance_variable_set(:@browser, @browser)
+      s = Watir::Screenshot.new @browser
       expect(s.send(:one_shot?)).to be_truthy
     end
   end

--- a/watir-screenshot-stitch.gemspec
+++ b/watir-screenshot-stitch.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = '~> 2.3'
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/watir-screenshot-stitch.gemspec
+++ b/watir-screenshot-stitch.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 
-  spec.add_dependency "watir", "~> 6.4"
+  spec.add_dependency "watir", "~> 6.12"
   spec.add_dependency "mini_magick", "~> 4.0"
   spec.add_dependency "os", "~> 1.0"
   spec.add_dependency "binding_of_caller", "~> 0.7"


### PR DESCRIPTION
Rewrite of #31 now that Watir 6.12 has (finally) been released.

@samnissen your blogpost for the website got auto-deleted when we force-pushed the new way of doing the website build. When you get the new release of this gem out, can you push up a new version rebased with source branch, and removing the need to pass in browser in the examples?

Thanks!