### PR TITLE
bug fix in 'base64_capable?' method to fetch browser name.

### DIFF
--- a/lib/watir-screenshot-stitch.rb
+++ b/lib/watir-screenshot-stitch.rb
@@ -85,7 +85,7 @@ module Watir
 
       # in IE & Safari a regular screenshot is a full page screenshot only
       def base64_capable?
-        [:internet_explorer, :safari].include? @browser.name
+        [:internet_explorer, :safari].include? @browser&.name
       end
 
       def one_shot?


### PR DESCRIPTION
Changed `@browser.name` to `@browser&.name`