### PR TITLE
Set ruby version >= 2.3.0 to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-ruby '>= 2.3.0'
-
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in watir-screenshot-stitch.gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+ruby '>= 2.3.0'
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in watir-screenshot-stitch.gemspec
 gemspec

--- a/watir-screenshot-stitch.gemspec
+++ b/watir-screenshot-stitch.gemspec
@@ -1,4 +1,3 @@
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "watir-screenshot-stitch/version"
@@ -34,6 +33,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "chunky_png", "~> 1.3"
+
+  spec.required_ruby_version = '>= 2.3.0'
 
   spec.add_dependency "rubyzip", "~> 1.2.2"
   spec.add_dependency "watir", "~> 6.4"


### PR DESCRIPTION
This PR will include the Ruby version >= 2.3.0 to the Gemfile because it is the first version which supports the Ruby safe-navigation-operator (&).