### PR TITLE
Reducing the scope of the rubyzip gem within the gemspec so that it i…

### DIFF
--- a/watir-screenshot-stitch.gemspec
+++ b/watir-screenshot-stitch.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.3.0'
 
-  spec.add_dependency "rubyzip", "~> 1.2.2"
+  spec.add_dependency "rubyzip", "~> 1.2"
   spec.add_dependency "watir", "~> 6.4"
   spec.add_dependency "mini_magick", "~> 4.0"
   spec.add_dependency "os", "~> 1.0"


### PR DESCRIPTION
…s more malleable to minor version changes

As referenced in issue #44, the gemspec declares the rubyzip dependency with all the way down to the patch version.  This change simply removes the hard set dependency on the patch version to allow incremental updates as needed.

Closes #44 