### PR TITLE
Update Rake version per advisory

### DIFF
--- a/lib/watir-screenshot-stitch/version.rb
+++ b/lib/watir-screenshot-stitch/version.rb
@@ -1,4 +1,4 @@
 module WatirScreenshotStitch
   NAME = 'watir-screenshot-stitch'
-  VERSION = "0.7.1"
+  VERSION = "0.7.2"
 end

--- a/watir-screenshot-stitch.gemspec
+++ b/watir-screenshot-stitch.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "chunky_png", "~> 1.3"
 


### PR DESCRIPTION
Per a GitHub security advisory, upgrade Rake version.