### PR TITLE
Remove dependency to ActiveSupport to find geckodriver

### DIFF
--- a/lib/watir-screenshot-stitch.rb
+++ b/lib/watir-screenshot-stitch.rb
@@ -149,7 +149,7 @@ module Watir
       end
 
       def webdrivers_defined?
-        'Webdrivers'.constantize
+        Object.const_get("Webdrivers")
       rescue
         nil
       end


### PR DESCRIPTION
`.constantize` is a method defined in ActiveRecord (https://apidock.com/rails/String/constantize) and not available for plain Ruby projects.

Replacing this line with `Object.const_get` will fix it, and will allow us to run in all environments.