### PR TITLE
Added Multithreading during actually image stitch. This depends on im…

### DIFF
--- a/lib/watir-screenshot-stitch.rb
+++ b/lib/watir-screenshot-stitch.rb
@@ -63,9 +63,10 @@ module Watir
 
       build_canvas
       gather_slices
-      stitch_together
-
-      @combined_screenshot.write @path
+      Thread.new do
+        stitch_together
+        @combined_screenshot.write @path
+      end
     end
 
     #


### PR DESCRIPTION
Ruby is thread locked so typically you wont see much improvement from multithreading unless ruby is waiting on an external resource. Image Magick can run while the ruby thread sleeps for a performance improvement.